### PR TITLE
Allow the debug binary process to finish graceful shutdown

### DIFF
--- a/v2/cmd/wails/flags/dev.go
+++ b/v2/cmd/wails/flags/dev.go
@@ -32,6 +32,7 @@ type Dev struct {
 	Save                 bool   `flag:"save" description:"Save the given flags as defaults"`
 	FrontendDevServerURL string `flag:"frontenddevserverurl" description:"The url of the external frontend dev server to use"`
 	ViteServerTimeout    int    `flag:"viteservertimeout" description:"The timeout in seconds for Vite server detection (default: 10)"`
+	ShutdownTimeout      int    `flag:"shutdowntimeout" description:"The timeout in seconds to wait for graceful shutdown (default: 10)"`
 
 	// Internal state
 	devServerURL  *url.URL
@@ -112,6 +113,13 @@ func (d *Dev) loadAndMergeProjectConfig() error {
 		d.ViteServerTimeout = 10 // Default timeout
 	}
 	d.projectConfig.ViteServerTimeout = d.ViteServerTimeout
+
+	if d.ShutdownTimeout == 0 && d.projectConfig.ShutdownTimeout != 0 {
+		d.ShutdownTimeout = d.projectConfig.ShutdownTimeout
+	} else if d.ShutdownTimeout == 0 {
+		d.ShutdownTimeout = 10 // Default timeout
+	}
+	d.projectConfig.ShutdownTimeout = d.ShutdownTimeout
 
 	if d.Save {
 		err = d.projectConfig.Save()

--- a/v2/cmd/wails/internal/dev/dev.go
+++ b/v2/cmd/wails/internal/dev/dev.go
@@ -132,8 +132,8 @@ func Application(f *flags.Dev, logger *clilogger.CLILogger) error {
 		return err
 	}
 	defer func() {
-		if err := killProcessAndCleanupBinary(debugBinaryProcess, appBinary); err != nil {
-			logutils.LogDarkYellow("Unable to kill process and cleanup binary: %s", err)
+		if err := stopProcessAndCleanupBinary(debugBinaryProcess, appBinary, quitChannel, projectConfig.ShutdownTimeout); err != nil {
+			logutils.LogDarkYellow("Unable to stop process and cleanup binary: %s", err)
 		}
 	}()
 
@@ -164,7 +164,7 @@ func Application(f *flags.Dev, logger *clilogger.CLILogger) error {
 	}
 
 	// Kill the current program if running and remove dev binary
-	if err := killProcessAndCleanupBinary(debugBinaryProcess, appBinary); err != nil {
+	if err := stopProcessAndCleanupBinary(debugBinaryProcess, appBinary, quitChannel, projectConfig.ShutdownTimeout); err != nil {
 		return err
 	}
 
@@ -177,11 +177,10 @@ func Application(f *flags.Dev, logger *clilogger.CLILogger) error {
 	return nil
 }
 
-func killProcessAndCleanupBinary(process *process.Process, binary string) error {
-	if process != nil && process.Running {
-		if err := process.Kill(); err != nil {
-			return err
-		}
+// stopProcessAndCleanupBinary will stop the app and cleanup the binary.
+func stopProcessAndCleanupBinary(process *process.Process, binary string, quitChannel <-chan os.Signal, shutdownTimeout int) error {
+	if err := stopApp(process, quitChannel, shutdownTimeout); err != nil {
+		return err
 	}
 
 	if binary != "" {
@@ -516,6 +515,34 @@ func doWatcherLoop(cwd string, reloadDirs string, buildOptions *build.Options, d
 		}
 	}
 	return debugBinaryProcess, nil
+}
+
+// stopApp attempts to wait for the app to gracefully shutdown. If it takes
+// longer than the shutdownTimeout to stop a kill signal is sent to terminate
+// the process.
+func stopApp(process *process.Process, quitChannel <-chan os.Signal, shutdownTimeout int) error {
+	if process == nil || !process.Running {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(shutdownTimeout))
+	defer cancel()
+	go func() {
+		// Cancel the timer if a quit signal is received.
+		<-quitChannel
+		cancel()
+	}()
+
+	logutils.LogGreen("Stopping app, waiting for process to stop...")
+	if err := process.Stop(); err != nil {
+		return fmt.Errorf("error stopping app: %w", err)
+	}
+
+	if err := process.KillWait(ctx); err != nil {
+		return fmt.Errorf("error killing app: %w", err)
+	}
+
+	return nil
 }
 
 func joinPath(url *url.URL, subPath string) string {

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -111,3 +111,5 @@ require (
 	howett.net/plist v1.0.0 // indirect
 	mvdan.cc/sh/v3 v3.7.0 // indirect
 )
+
+replace github.com/wailsapp/wails/v2 => /home/jesse/dev/github.com/JDWardle/wails/v2

--- a/v2/internal/process/process.go
+++ b/v2/internal/process/process.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"os"
 	"os/exec"
 )
@@ -8,7 +9,7 @@ import (
 // Process defines a process that can be executed
 type Process struct {
 	cmd         *exec.Cmd
-	exitChannel chan bool
+	exitChannel chan struct{}
 	Running     bool
 }
 
@@ -16,7 +17,7 @@ type Process struct {
 func NewProcess(cmd string, args ...string) *Process {
 	result := &Process{
 		cmd:         exec.Command(cmd, args...),
-		exitChannel: make(chan bool, 1),
+		exitChannel: make(chan struct{}),
 	}
 	result.cmd.Stdout = os.Stdout
 	result.cmd.Stderr = os.Stderr
@@ -32,14 +33,15 @@ func (p *Process) Start(exitCodeChannel chan int) error {
 
 	p.Running = true
 
-	go func(cmd *exec.Cmd, running *bool, exitChannel chan bool, exitCodeChannel chan int) {
+	go func(cmd *exec.Cmd, running *bool, exitCodeChannel chan int) {
+		defer close(p.exitChannel)
+
 		err := cmd.Wait()
 		if err == nil {
 			exitCodeChannel <- 0
 		}
 		*running = false
-		exitChannel <- true
-	}(p.cmd, &p.Running, p.exitChannel, exitCodeChannel)
+	}(p.cmd, &p.Running, exitCodeChannel)
 
 	return nil
 }
@@ -58,10 +60,19 @@ func (p *Process) Kill() error {
 		return err
 	}
 
-	// Wait for command to exit properly
-	<-p.exitChannel
-
 	return err
+}
+
+// KillWait kills the process once the provided context is canceled. If the
+// process terminates while waiting this returns early without error.
+func (p *Process) KillWait(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+	case <-p.exitChannel:
+		return nil
+	}
+
+	return p.Kill()
 }
 
 // PID returns the process PID

--- a/v2/internal/process/process_other.go
+++ b/v2/internal/process/process_other.go
@@ -1,0 +1,19 @@
+//go:build darwin || linux
+// +build darwin linux
+
+package process
+
+import "syscall"
+
+// Stop sends a SIGTERM signal to the process.
+func (p *Process) Stop() error {
+	if !p.Running {
+		return nil
+	}
+
+	if err := p.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/v2/internal/process/process_windows.go
+++ b/v2/internal/process/process_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+// +build windows
+
+package process
+
+// Stop is a no-op on Windows. Interrupts are not supported on Windows for
+// detached processes https://github.com/golang/go/issues/46345.
+func (p *Process) Stop() error { return nil }

--- a/v2/internal/project/project.go
+++ b/v2/internal/project/project.go
@@ -99,6 +99,9 @@ type Project struct {
 	// The timeout in seconds for Vite server detection. Default 10
 	ViteServerTimeout int `json:"viteServerTimeout"`
 
+	// The timeout in seconds to wait for graceful application shutdown, Default 10
+	ShutdownTimeout int `json:"shutdownTimeout"`
+
 	Bindings Bindings `json:"bindings"`
 }
 

--- a/website/docs/reference/cli.mdx
+++ b/website/docs/reference/cli.mdx
@@ -209,6 +209,7 @@ Your system is ready for Wails development!
 | -tags "extra tags"           | Build tags to pass to compiler (quoted and space separated)                                                                                                                         |                       |
 | -v                           | Verbosity level (0 - silent, 1 - standard, 2 - verbose)                                                                                                                             | 1                     |
 | -wailsjsdir                  | The directory to generate the generated Wails JS modules                                                                                                                            | Value in `wails.json` |
+| -shutdowntimeout             | The timeout in seconds to wait for graceful shutdown                                                                                                                                | 10                    |
 
 Example:
 

--- a/website/docs/reference/project-config.mdx
+++ b/website/docs/reference/project-config.mdx
@@ -38,6 +38,8 @@ The project config resides in the `wails.json` file in the project directory. Th
   "frontend:dev:serverUrl": "",
   // The timeout in seconds for Vite server detection when frontend:dev:serverUrl is set to 'auto'. Default: 10
   "viteServerTimeout": 10,
+  // The timeout in seconds to wait for graceful shutdown. Default: 10
+  "shutdownTimeout": 10,
   // Relative path to the directory that the auto-generated JS modules will be created
   "wailsjsdir": "",
   // The name of the binary

--- a/website/src/pages/changelog.mdx
+++ b/website/src/pages/changelog.mdx
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ContentProtection` option to allow hiding the application window from screen sharing software [#4241](https://github.com/wailsapp/wails/pull/4241) by [@Taiterbase](https://github.com/Taiterbase)
 - Added `build:tags` to project specification for automatically adding compilation tags by @symball in [PR](https://github.com/wailsapp/wails/pull/4439)
 - Support for binding generics in [PR](https://github.dev/wailsapp/wails/pull/3626) by @ktsivkov
+- Changed dev command to wait for graceful shutdown of the application with shutdown timeout configuration through the `-shutdowntimeout` flag and `shutdownTimeout` project config setting by @jdwardle in [PR}()
 
 ### Fixed
 - Added url validation for BrowserOpenURL by @APshenkin in [PR](https://github.com/wailsapp/wails/pull/4484)


### PR DESCRIPTION
<!--

*********************************************************************
*               PLEASE READ BEFORE SUBMITTING YOUR PR               *
*     YOUR PR MAY BE REJECTED IF IT DOES NOT FOLLOW THESE STEPS     *
*********************************************************************

- *DO NOT* submit PRs for v3 alpha enhancements, unless you have opened a post on the discord channel.
  All enhancements must be discussed first.
  The feedback guide for v3 is here: https://v3alpha.wails.io/getting-started/feedback/

- Before submitting your PR, please ensure you have created and linked the PR to an issue.
- If a relevant issue already exists, please reference it in your PR by including `Fixes #<issue number>` in your PR description.
- Please fill in the checklists.

-->

# Description

This change will allow applications running with `wails dev` to perform their `OnBeforeClose` and `OnShutdown` functions before terminating when an interrupt signal is sent to the console (Ctrl+C). This introduces a shutdown timeout flag and project config setting that only allows the graceful shutdown to block for the set duration. Since the dev command stops the watcher a timeout is needed to ensure the application stops at some point as changes will no longer be re-built.

Fixes #3077 

## Type of change
  
Please select the option that is relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
  
This was tested with a new wails application `wails init -n samplewails -t vanilla-ts` on Windows 11, Pop!_OS 22.04 and Mac Sonoma.

The application used for testing this change contains a message dialog in  the `OnBeforeShutdown` callback that prevents shutdown until the dialog is dismissed. The changes in this PR will allow that dialog to be displayed until the shutdown timeout has been reached. If it's dismissed before the shutdown timeout is reached the dev command will immediately continue with it's shutdown logic.

No other changes were made to the vanilla-ts generated project.

## main.go
```go
package main

import (
	"context"
	"embed"
	"log"

	"github.com/wailsapp/wails/v2"
	"github.com/wailsapp/wails/v2/pkg/options"
	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
	"github.com/wailsapp/wails/v2/pkg/runtime"
)

//go:embed all:frontend/dist
var assets embed.FS

func main() {
	// Create an instance of the app structure
	app := NewApp()

	// Create application with options
	err := wails.Run(&options.App{
		Title:  "samplewails",
		Width:  1024,
		Height: 768,
		AssetServer: &assetserver.Options{
			Assets: assets,
		},
		OnBeforeClose: func(ctx context.Context) (prevent bool) {
			result, err := runtime.MessageDialog(ctx, runtime.MessageDialogOptions{
				Type:    runtime.QuestionDialog,
				Title:   "Shutdown prevented",
				Message: "App will not close until the shutdown timeout has been reached or this dialog is dismissed.",
			})
			if err != nil {
				log.Println("error:", err)
			} else {
				log.Println("result:", result)
			}

			return false
		},
		BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
		OnStartup:        app.startup,
		Bind: []interface{}{
			app,
		},
	})

	if err != nil {
		println("Error:", err.Error())
	}
}

```

- [x] Windows
  - Windows does not support interrupt signals for detached processes. Even though Ctrl+C starts the shutdown process, sending another Interrupt signal or Ctrl+Break key event is not supported. The changes here still work without being able to send the interrupt signal but cause some less than ideal behavior with the app displaying an empty page.

  <img width="2458" height="1351" alt="windows" src="https://github.com/user-attachments/assets/42d2f8af-7617-4bac-929c-7ce09fbd78b9" />


- [x] macOS
- [x] Linux (Pop!_OS 22.04)
  
## Test Configuration

### Windows 11
```
# Wails
Version  | v2.10.2
Revision | 5b384a4d9f1f553a6fe710bde39a114d89853379
Modified | true


# System
┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
| OS           | Windows 10 Pro                                                                    |
| Version      | 2009 (Build: 26100)                                                               |
| ID           | 24H2                                                                              |
| Branding     | Windows 11 Pro                                                                    |
| Go Version   | go1.25.1                                                                          |
| Platform     | windows                                                                           |
| Architecture | amd64                                                                             |
| CPU          | AMD Ryzen 9 7900X 12-Core Processor                                               |
| GPU 1        | AMD Radeon RX 7900 XT (Advanced Micro Devices, Inc.) - Driver: 32.0.21025.10016   |
| GPU 2        | AMD Radeon(TM) Graphics (Advanced Micro Devices, Inc.) - Driver: 32.0.21025.10016 |
| Memory       | 32GB                                                                              |
└──────────────────────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌───────────────────────────────────────────────────────┐
| Dependency | Package Name | Status    | Version       |
| WebView2   | N/A          | Installed | 140.0.3485.94 |
| Nodejs     | N/A          | Installed | 22.20.0       |
| npm        | N/A          | Installed | 10.9.3        |
| *upx       | N/A          | Available |               |
| *nsis      | N/A          | Available |               |
|                                                       |
└─────────────── * - Optional Dependency ───────────────┘

# Diagnosis
Optional package(s) installation details:
  - upx : Available at https://upx.github.io/
  - nsis : More info at https://wails.io/docs/guides/windows-installer/

 SUCCESS  Your system is ready for Wails development!
```

### MacOS Sonoma
```
```

### Linux (Pop!_OS 22.04)
```
# Wails
Version         | v2.10.2                                 
Revision        | 4df077f9b26526552aff934203c577d0367d15ac
Modified        | true                                    
Package Manager | apt                                     


# System
WARNING: failed to read int from file: open /sys/devices/system/cpu/cpu0/online: no such file or directory
┌──────────────────────────────────────────────────────────────────────────────────┐
| OS           | Pop!_OS                                                           |
| Version      | 22.04                                                             |
| ID           | pop                                                               |
| Branding     |                                                                   |
| Go Version   | go1.23.3                                                          |
| Platform     | linux                                                             |
| Architecture | amd64                                                             |
| CPU          | AMD Ryzen 7 7840HS w/ Radeon 780M Graphics                        |
| GPU          | unknown (Advanced Micro Devices, Inc. [AMD/ATI]) - Driver: amdgpu |
| Memory       | 64GB                                                              |
└──────────────────────────────────────────────────────────────────────────────────┘

# Dependencies
┌──────────────────────────────────────────────────────────────────────────┐
| Dependency | Package Name          | Status    | Version                 |
| *docker    | docker.io             | Installed | 28.3.3-rd               |
| gcc        | build-essential       | Installed | 12.9ubuntu3             |
| libgtk-3   | libgtk-3-dev          | Installed | 3.24.33-1ubuntu2.2      |
| libwebkit  | libwebkit2gtk-4.0-dev | Installed | 2.48.5-0ubuntu0.22.04.1 |
| npm        | npm                   | Installed | 10.9.3                  |
| *nsis      | nsis                  | Installed | v3.08-2                 |
| pkg-config | pkg-config            | Installed | 0.29.2-1ubuntu3         |
|                                                                          |
└──────────────────────── * - Optional Dependency ─────────────────────────┘

# Diagnosis
 SUCCESS  Your system is ready for Wails development!
```

# Checklist:

- [ ] I have updated `website/src/pages/changelog.mdx` with details of this PR
- [ ] My code follows the general coding style of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
